### PR TITLE
Upgrade sys package for Darwin with go v1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,5 @@ require (
 	github.com/rs/xid v1.2.1
 	golang.org/x/crypto v0.0.0-20200117160349-530e935923ad
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e // indirect
+	golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f h1:8w7RhxzTVgUzw/AH/9mUV5q0vMgy40SQRursCcfmkCw=
+golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=


### PR DESCRIPTION
`gomi` is a great useful product, thank you.

### Problem
On Darwin with Go v1.18.0, `$ go build` is failed as below.

```bash
$ go build
# golang.org/x/sys/unix
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:28:3: //go:linkname must refer to declared function or variable
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:43:3: //go:linkname must refer to declared function or variable
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:59:3: //go:linkname must refer to declared function or variable
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:75:3: //go:linkname must refer to declared function or variable
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:90:3: //go:linkname must refer to declared function or variable
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:105:3: //go:linkname must refer to declared function or variable
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:121:3: //go:linkname must refer to declared function or variable
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:136:3: //go:linkname must refer to declared function or variable
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:151:3: //go:linkname must refer to declared function or variable
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:166:3: //go:linkname must refer to declared function or variable
/Users/foo/go/1.18.0/pkg/mod/golang.org/x/sys@v0.0.0-20190726091711-fc99dfbffb4e/unix/zsyscall_darwin_amd64.go:166:3: too many errors
```

### How to fix
- Upgrade `golang.org/x/sys`

```bash
$ go get golang.org/x/sys
go: upgraded golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e => v0.0.0-20220408201424-a24fb2fb8a0f
```

### Check

```bash
$ go build

$ ./gomi -h
Usage:
  gomi [OPTIONS]
```

### Note
Ubuntu or less than `v1.18` has no problem.
